### PR TITLE
Add search bar and duration over thumbnails

### DIFF
--- a/oetube/angular/src/app/route.provider.ts
+++ b/oetube/angular/src/app/route.provider.ts
@@ -28,12 +28,6 @@ function configureRoutes(routesService: RoutesService) {
         order: 3,
         layout: eLayoutType.application,
       },
-      {
-        path: '/dev-extreme',
-        name: 'Dev Extreme',
-        order: 4,
-        layout: eLayoutType.application,
-      },
     ]);
   };
 }

--- a/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.html
+++ b/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.html
@@ -1,11 +1,15 @@
 <div class="input-group">
-  <dx-text-box placeholder="Search" (onEnterKey)="onSearch()" class="w-100 rounded-pill">
+  <dx-text-box
+    placeholder="Search"
+    (onEnterKey)="onSearch()"
+    [(value)]="searchPhrase"
+    class="w-100 rounded-pill"
+  >
     <dxi-button
       name="search"
       [options]="searchButtonOptions"
       text="Search"
       icon="search"
-      (onClick)="onSearch()"
     ></dxi-button>
   </dx-text-box>
 </div>

--- a/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.html
+++ b/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.html
@@ -1,0 +1,11 @@
+<div class="input-group">
+  <dx-text-box placeholder="Search" (onEnterKey)="onSearch()" class="w-100 rounded-pill">
+    <dxi-button
+      name="search"
+      [options]="searchButtonOptions"
+      text="Search"
+      icon="search"
+      (onClick)="onSearch()"
+    ></dxi-button>
+  </dx-text-box>
+</div>

--- a/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.spec.ts
+++ b/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SearchBarComponent } from './search-bar.component';
+
+describe('SearchBarComponent', () => {
+  let component: SearchBarComponent;
+  let fixture: ComponentFixture<SearchBarComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SearchBarComponent]
+    });
+    fixture = TestBed.createComponent(SearchBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.ts
+++ b/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, EventEmitter, Output } from '@angular/core';
+
+import { ClickEvent } from 'devextreme/ui/button';
 
 @Component({
   selector: 'app-search-bar',
@@ -6,12 +8,19 @@ import { Component } from '@angular/core';
   styleUrls: ['./search-bar.component.scss'],
 })
 export class SearchBarComponent {
+  @Output() searchClicked = new EventEmitter<string>();
+
+  public searchPhrase: string;
+
   searchButtonOptions = {
     icon: 'search',
     disabled: false,
     visible: true,
     stylingMode: 'text',
+    onClick: () => this.onSearch(),
   };
 
-  onSearch() {}
+  onSearch() {
+    this.searchClicked.emit(this.searchPhrase);
+  }
 }

--- a/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.ts
+++ b/oetube/angular/src/app/video/video-grid/search-bar/search-bar.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-search-bar',
+  templateUrl: './search-bar.component.html',
+  styleUrls: ['./search-bar.component.scss'],
+})
+export class SearchBarComponent {
+  searchButtonOptions = {
+    icon: 'search',
+    disabled: false,
+    visible: true,
+    stylingMode: 'text',
+  };
+
+  onSearch() {}
+}

--- a/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.html
+++ b/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.html
@@ -1,8 +1,15 @@
-<div *ngIf="(videos$ | async)?.length === 0">No records found.</div>
+<div class="container mb-5">
+  <app-search-bar></app-search-bar>
+</div>
+
+<div *ngIf="(videos$ | async)?.length === 0">No videos found.</div>
 <div class="container">
   <div class="row gx-5 gy-4 row-cols-1 row-cols-md-3 row-cols-lg-4">
     <div *ngFor="let video of videos$ | async" class="col position-relative">
-      <img class="rounded my-1 w-100" [src]="'https://picsum.photos/300/200?r=' + video.Id" />
+      <div class="pic-container">
+        <img class="rounded my-1 w-100" [src]="'https://picsum.photos/300/200?r=' + video.Id" />
+        <div class="bottom-right">{{ fromatVideoDuration(video.Duration) }}</div>
+      </div>
       <div class="text-truncate" [title]="video.Name">
         <a
           [routerLink]="['video', 'watch', video.Id]"

--- a/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.html
+++ b/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.html
@@ -1,8 +1,11 @@
 <div class="container mb-5">
-  <app-search-bar></app-search-bar>
+  <app-search-bar (searchClicked)="onSearch($event)"></app-search-bar>
 </div>
 
-<div *ngIf="(videos$ | async)?.length === 0">No videos found.</div>
+<div *ngIf="!isLoading && (videos$ | async)?.length === 0">No videos found.</div>
+<div *ngIf="isLoading" class="text-center">
+  <dx-load-indicator [height]="60" [width]="60"> </dx-load-indicator>
+</div>
 <div class="container">
   <div class="row gx-5 gy-4 row-cols-1 row-cols-md-3 row-cols-lg-4">
     <div *ngFor="let video of videos$ | async" class="col position-relative">

--- a/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.scss
+++ b/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.scss
@@ -1,0 +1,14 @@
+/* Bottom right text */
+.bottom-right {
+  position: absolute;
+  bottom: 8px;
+  right: 5px;
+  background-color: rgba(0, 0, 0, 0.3);
+  padding: 0px 8px;
+}
+
+.pic-container {
+  position: relative;
+  text-align: center;
+  color: white;
+}

--- a/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.ts
+++ b/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.ts
@@ -44,7 +44,7 @@ export class VideoGridComponent implements OnInit {
         Id: '3',
         Name: 'Informative video',
         Description: 'Something witty',
-        Duration: 20345,
+        Duration: 30,
         CreationTime: new Date(),
         CreatorId: 'guid2',
       } as Video,
@@ -65,5 +65,11 @@ export class VideoGridComponent implements OnInit {
         CreatorId: 'guid2',
       } as Video,
     ]);
+  }
+
+  fromatVideoDuration(duration: number) {
+    const date = new Date(null);
+    date.setSeconds(duration);
+    return date.toISOString().slice(11, 19);
   }
 }

--- a/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.ts
+++ b/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.ts
@@ -22,6 +22,14 @@ export class VideoGridComponent implements OnInit {
   public videos$: Observable<Video[]>;
 
   ngOnInit(): void {
+    this.refreshVideos();
+  }
+
+  onSearch(searchPhrase: string) {
+    this.refreshVideos(searchPhrase);
+  }
+
+  refreshVideos(searchPhrase?: string) {
     //Observable from Create Method
     this.videos$ = of([
       {

--- a/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.ts
+++ b/oetube/angular/src/app/video/video-grid/video-grid/video-grid.component.ts
@@ -18,8 +18,8 @@ export type Video = {
   styleUrls: ['./video-grid.component.scss'],
 })
 export class VideoGridComponent implements OnInit {
-  //TODO make this @input
   public videos$: Observable<Video[]>;
+  public isLoading: boolean;
 
   ngOnInit(): void {
     this.refreshVideos();
@@ -31,48 +31,57 @@ export class VideoGridComponent implements OnInit {
 
   refreshVideos(searchPhrase?: string) {
     //Observable from Create Method
-    this.videos$ = of([
-      {
-        Id: '1',
-        Name: 'Test video',
-        Description: 'Placeholder description',
-        Duration: 5000,
-        CreationTime: new Date(),
-        CreatorId: 'guid',
-      } as Video,
-      {
-        Id: '2',
-        Name: 'Placeholder video',
-        Description: 'Something witty',
-        Duration: 20345,
-        CreationTime: new Date(),
-        CreatorId: 'guid2',
-      } as Video,
-      {
-        Id: '3',
-        Name: 'Informative video',
-        Description: 'Something witty',
-        Duration: 30,
-        CreationTime: new Date(),
-        CreatorId: 'guid2',
-      } as Video,
-      {
-        Id: '4',
-        Name: 'Just another movie',
-        Description: 'With a nice description',
-        Duration: 20345,
-        CreationTime: new Date(),
-        CreatorId: 'guid2',
-      } as Video,
-      {
-        Id: '5',
-        Name: 'Just another video with a rather long title which should never fit on the users screen',
-        Description: 'With a nice description',
-        Duration: 20345,
-        CreationTime: new Date(),
-        CreatorId: 'guid2',
-      } as Video,
-    ]);
+    this.videos$ = undefined;
+    this.isLoading = true;
+
+    // TODO use service
+    // This is only to simulate loading times
+    setTimeout(() => {
+      this.videos$ = of([
+        {
+          Id: '1',
+          Name: 'Test video',
+          Description: 'Placeholder description',
+          Duration: 5000,
+          CreationTime: new Date(),
+          CreatorId: 'guid',
+        } as Video,
+        {
+          Id: '2',
+          Name: 'Placeholder video',
+          Description: 'Something witty',
+          Duration: 20345,
+          CreationTime: new Date(),
+          CreatorId: 'guid2',
+        } as Video,
+        {
+          Id: '3',
+          Name: 'Informative video',
+          Description: 'Something witty',
+          Duration: 30,
+          CreationTime: new Date(),
+          CreatorId: 'guid2',
+        } as Video,
+        {
+          Id: '4',
+          Name: 'Just another movie',
+          Description: 'With a nice description',
+          Duration: 20345,
+          CreationTime: new Date(),
+          CreatorId: 'guid2',
+        } as Video,
+        {
+          Id: '5',
+          Name: 'Just another video with a rather long title which should never fit on the users screen',
+          Description: 'With a nice description',
+          Duration: 20345,
+          CreationTime: new Date(),
+          CreatorId: 'guid2',
+        } as Video,
+      ]);
+
+      this.isLoading = false;
+    }, 1000 + Math.random() * 3000);
   }
 
   fromatVideoDuration(duration: number) {

--- a/oetube/angular/src/app/video/video.module.ts
+++ b/oetube/angular/src/app/video/video.module.ts
@@ -1,9 +1,15 @@
-import { DxButtonModule, DxSliderModule, DxTextBoxModule } from 'devextreme-angular';
+import {
+  DxButtonModule,
+  DxLoadIndicatorModule,
+  DxSliderModule,
+  DxTextBoxModule,
+} from 'devextreme-angular';
 
 import { CommonModule } from '@angular/common';
 import { ControlBarComponent } from './video-player/control-bar/control-bar.component';
 import { NgModule } from '@angular/core';
 import { PlayControlComponent } from './video-player/play-control/play-control.component';
+import { SearchBarComponent } from './video-grid/search-bar/search-bar.component';
 import { TimeComponent } from './video-player/time/time.component';
 import { VideoComponent } from './video.component';
 import { VideoGridComponent } from './video-grid/video-grid/video-grid.component';
@@ -12,7 +18,6 @@ import { VideoRoutingModule } from './video-routing.module';
 import { VideoSeekerComponent } from './video-player/video-seeker/video-seeker.component';
 import { VideoWrapperComponent } from './video-player/video-wrapper/video-wrapper.component';
 import { VolumeControlComponent } from './video-player/volume-control/volume-control.component';
-import { SearchBarComponent } from './video-grid/search-bar/search-bar.component';
 
 @NgModule({
   declarations: [
@@ -27,6 +32,13 @@ import { SearchBarComponent } from './video-grid/search-bar/search-bar.component
     VideoGridComponent,
     SearchBarComponent,
   ],
-  imports: [CommonModule, VideoRoutingModule, DxSliderModule, DxButtonModule, DxTextBoxModule],
+  imports: [
+    CommonModule,
+    VideoRoutingModule,
+    DxSliderModule,
+    DxButtonModule,
+    DxTextBoxModule,
+    DxLoadIndicatorModule,
+  ],
 })
 export class VideoModule {}

--- a/oetube/angular/src/app/video/video.module.ts
+++ b/oetube/angular/src/app/video/video.module.ts
@@ -1,6 +1,7 @@
+import { DxButtonModule, DxSliderModule, DxTextBoxModule } from 'devextreme-angular';
+
 import { CommonModule } from '@angular/common';
 import { ControlBarComponent } from './video-player/control-bar/control-bar.component';
-import { DxSliderModule } from 'devextreme-angular';
 import { NgModule } from '@angular/core';
 import { PlayControlComponent } from './video-player/play-control/play-control.component';
 import { TimeComponent } from './video-player/time/time.component';
@@ -11,6 +12,7 @@ import { VideoRoutingModule } from './video-routing.module';
 import { VideoSeekerComponent } from './video-player/video-seeker/video-seeker.component';
 import { VideoWrapperComponent } from './video-player/video-wrapper/video-wrapper.component';
 import { VolumeControlComponent } from './video-player/volume-control/volume-control.component';
+import { SearchBarComponent } from './video-grid/search-bar/search-bar.component';
 
 @NgModule({
   declarations: [
@@ -23,7 +25,8 @@ import { VolumeControlComponent } from './video-player/volume-control/volume-con
     TimeComponent,
     ControlBarComponent,
     VideoGridComponent,
+    SearchBarComponent,
   ],
-  imports: [CommonModule, VideoRoutingModule, DxSliderModule],
+  imports: [CommonModule, VideoRoutingModule, DxSliderModule, DxButtonModule, DxTextBoxModule],
 })
 export class VideoModule {}


### PR DESCRIPTION
The homepage simulates the search functionality by loading the same placeholder videos with a random delay.

The duration of each video is displayed over the thumbnails